### PR TITLE
Replace “Pyhton” with “Python” and correct capitalisation

### DIFF
--- a/projects/_posts/2014-07-08-cappucino.markdown
+++ b/projects/_posts/2014-07-08-cappucino.markdown
@@ -3,7 +3,7 @@ layout: default
 maintainers: cacaodev
 homepage: https://github.com/cacaodev/cappuccino/tree/Autolayout
 repo: https://github.com/cacaodev/cappuccino/tree/Autolayout
-language: Javascript / Objective-J
+language: JavaScript / Objective-J
 name: Cappucino Auto Layout
 preamble: Cappuccino is an open source framework that makes it easy to build desktop-caliber applications that run in a web browser.
 description: Cappuccino is built on top of standard web technologies like JavaScript, and it implements most of the familiar APIs from GNUstep and Apple's Cocoa frameworks. When you program in Cappuccino, you don't need to concern yourself with the complexities of traditional web technologies like HTML, CSS, or even the DOM. The unpleasantries of building complex cross browser applications are abstracted away for you.

--- a/projects/_posts/2014-07-10-pybee.markdown
+++ b/projects/_posts/2014-07-10-pybee.markdown
@@ -3,7 +3,7 @@ layout: default
 maintainers: Russell Keith-Magee
 homepage: https://github.com/pybee/cassowary
 repo: https://github.com/pybee/cassowary
-language: Pyhton
+language: Python
 name: Pybee Cassowary
 preamble: A pure Python implementation of the Cassowary constraint-solving algorithm.
 description: Cassowary is compatible with both Python 2 or Python 3.

--- a/projects/_posts/2014-07-11-angular.markdown
+++ b/projects/_posts/2014-07-11-angular.markdown
@@ -3,7 +3,7 @@ layout: default
 maintainers: Alex Birkett
 homepage: http://thenikso.github.io/angular-autolayout/
 repo: https://github.com/thenikso/angular-autolayout
-language: Javascript
+language: JavaScript
 name: Angular Auto Layout
 preamble: Constraint based layout for your AngularJS apps
 description: Constraint based layout paradigm for AngularJS web applications inspired by Apple's Auto Layout for iOS and OS X. <br /><br />HTML and CSS have been designed to present a page style layout like one that you might find on a newspaper. However, nowadays those technologies are also used to for layout of applications that should resemble native ones. <br /><br />Many features that are needed to properly layout an application are missing from CSS. For example, there is no way to specify that two elements on a page should have the same height! <br /><br />With angular-autolayout, you can use the same layout technology that Apple gives to native iOS and OS X developers for your HTML5 app.

--- a/projects/_posts/2014-07-14-gss.markdown
+++ b/projects/_posts/2014-07-14-gss.markdown
@@ -3,7 +3,7 @@ layout: default
 maintainers: thegrid.io
 homepage: http://gridstylesheets.org/
 repo: https://github.com/gss/engine/
-language: Javascript
+language: JavaScript
 name: Grid Style Sheets
 preamble: GSS is a CSS preprocessor & JS runtime that harnesses Cassowary.js
 description: GSS reimagines CSS layout & replaces the browser’s layout engine with one that harnesses the Cassowary Constraint Solver — the same algorithm Apple uses to compute native layout.

--- a/projects/_posts/2014-07-15-casuarius.markdown
+++ b/projects/_posts/2014-07-15-casuarius.markdown
@@ -3,7 +3,7 @@ layout: default
 maintainers: Enthought
 homepage: https://github.com/enthought/casuarius
 repo: https://github.com/enthought/casuarius
-language: C / Pyhton
+language: C / Python
 name: Casuarius
 preamble: Cython binding for Cassowary
 description: The solver source code is derived from the 0.6 release of Cassowary. It has been modified by Svilen Dobrev to remove memory leaks.

--- a/projects/_posts/2014-07-16-kiwi.markdown
+++ b/projects/_posts/2014-07-16-kiwi.markdown
@@ -3,7 +3,7 @@ layout: default
 maintainers: Chris Colbert
 homepage: https://github.com/nucleic/kiwi
 repo: https://github.com/nucleic/kiwi
-language: C++ (and pyhton bindings)
+language: C++ (and Python bindings)
 name: Kiwi
 preamble: A new implementation of the algorithm based on the seminal Cassowary paper
 description: Kiwi is an efficient C++ implementation of the Cassowary constraint solving algorithm. Kiwi is an implementation of the algorithm based on the seminal Cassowary paper. It is not a refactoring of the original C++ solver. Kiwi has been designed from the ground up to be lightweight and fast. Kiwi ranges from 10x to 500x faster than the original Cassowary solver with typical use cases gaining a 40x improvement. Memory savings are consistently > 5x. In addition to the C++ solver, Kiwi ships with hand-rolled Python bindings.

--- a/projects/_posts/2014-07-17-rhea.markdown
+++ b/projects/_posts/2014-07-17-rhea.markdown
@@ -5,7 +5,7 @@ homepage: https://github.com/Nocte-/rhea
 repo: https://github.com/Nocte-/rhea
 language: C++
 name: Rhea
-preamble: Cassowary in modern c++
+preamble: Cassowary in modern C++
 description: Rhea is an incremental constraint solver based on Cassowary, originally developed by Greg J. Badros and Alan Borning. The main differences are <ul><li>Allows the programmer to write constraints in a natural way</li><li>Rewritten in C++11</li><li>CMake instead of GNU Autoconfig</li><li>Unit tests use the Boost Test Framework</li><li>Uses Doxygen for documentation</li><li>Expression parser based on Boost Spirit</li><li>Does not have a finite domain subsolver</li></ul>
 
 ---


### PR DESCRIPTION
Typo fixes. Great site! :+1: 
